### PR TITLE
feat: some improvements to new features

### DIFF
--- a/app/src/main/java/com/aliernfrog/ensimanager/ui/component/form/RadioButtons.kt
+++ b/app/src/main/java/com/aliernfrog/ensimanager/ui/component/form/RadioButtons.kt
@@ -23,10 +23,11 @@ fun RadioButtons(
     colors: RadioButtonColors = RadioButtonDefaults.colors(),
     onSelect: (Int) -> Unit
 ) {
-    choices.forEachIndexed { index, choice ->
+    choices.forEachIndexed { i, choice ->
+        val index = choice.indexOverride ?: i
         val selected = selectedOptionIndex == index
         val onSelected = {
-            onSelect(choice.indexOverride ?: index)
+            onSelect(index)
         }
         Row(
             verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/aliernfrog/ensimanager/ui/component/form/RadioButtons.kt
+++ b/app/src/main/java/com/aliernfrog/ensimanager/ui/component/form/RadioButtons.kt
@@ -8,7 +8,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.RadioButtonColors
 import androidx.compose.material3.RadioButtonDefaults
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -45,13 +44,10 @@ fun RadioButtons(
             FormHeader(
                 title = choice.title,
                 description = choice.description,
+                contentColor = contentColor,
                 modifier = Modifier.alpha(
                     if (choice.enabled) 1f else 0.7f
                 )
-            )
-            Text(
-                text = choice.title,
-                color = contentColor
             )
         }
     }

--- a/app/src/main/java/com/aliernfrog/ensimanager/ui/component/form/RadioButtons.kt
+++ b/app/src/main/java/com/aliernfrog/ensimanager/ui/component/form/RadioButtons.kt
@@ -18,14 +18,14 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun RadioButtons(
     choices: List<RadioButtonChoice>,
-    selectedOptionIndex: Int,
+    selectedIndex: Int,
     contentColor: Color = MaterialTheme.colorScheme.onSurface,
     colors: RadioButtonColors = RadioButtonDefaults.colors(),
     onSelect: (Int) -> Unit
 ) {
     choices.forEachIndexed { i, choice ->
         val index = choice.indexOverride ?: i
-        val selected = selectedOptionIndex == index
+        val selected = selectedIndex == index
         val onSelected = {
             onSelect(index)
         }

--- a/app/src/main/java/com/aliernfrog/ensimanager/ui/component/form/RadioButtons.kt
+++ b/app/src/main/java/com/aliernfrog/ensimanager/ui/component/form/RadioButtons.kt
@@ -33,7 +33,10 @@ fun RadioButtons(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
                 .fillMaxWidth()
-                .clickable { onSelected() }
+                .let {
+                    if (choice.enabled) it.clickable { onSelected() }
+                    else it
+                }
                 .padding(horizontal = 2.dp)
         ) {
             RadioButton(

--- a/app/src/main/java/com/aliernfrog/ensimanager/ui/component/form/RadioButtons.kt
+++ b/app/src/main/java/com/aliernfrog/ensimanager/ui/component/form/RadioButtons.kt
@@ -1,4 +1,4 @@
-package com.aliernfrog.ensimanager.ui.component
+package com.aliernfrog.ensimanager.ui.component.form
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
@@ -12,20 +12,23 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 
 @Composable
 fun RadioButtons(
-    options: List<String>,
+    choices: List<RadioButtonChoice>,
     selectedOptionIndex: Int,
     contentColor: Color = MaterialTheme.colorScheme.onSurface,
     colors: RadioButtonColors = RadioButtonDefaults.colors(),
     onSelect: (Int) -> Unit
 ) {
-    options.forEachIndexed { index, option ->
+    choices.forEachIndexed { index, choice ->
         val selected = selectedOptionIndex == index
-        val onSelected = { onSelect(index) }
+        val onSelected = {
+            onSelect(choice.indexOverride ?: index)
+        }
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
@@ -36,12 +39,27 @@ fun RadioButtons(
             RadioButton(
                 selected = selected,
                 onClick = { onSelected() },
-                colors = colors
+                colors = colors,
+                enabled = choice.enabled
+            )
+            FormHeader(
+                title = choice.title,
+                description = choice.description,
+                modifier = Modifier.alpha(
+                    if (choice.enabled) 1f else 0.7f
+                )
             )
             Text(
-                text = option,
+                text = choice.title,
                 color = contentColor
             )
         }
     }
 }
+
+data class RadioButtonChoice(
+    val title: String,
+    val description: String? = null,
+    val enabled: Boolean = true,
+    val indexOverride: Int? = null
+)

--- a/app/src/main/java/com/aliernfrog/ensimanager/ui/screen/APIScreen.kt
+++ b/app/src/main/java/com/aliernfrog/ensimanager/ui/screen/APIScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.automirrored.filled.SpeakerNotes
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Api
-import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.EnhancedEncryption
@@ -74,8 +73,6 @@ import com.aliernfrog.ensimanager.ui.component.SettingsButton
 import com.aliernfrog.ensimanager.ui.component.TextWithIcon
 import com.aliernfrog.ensimanager.ui.component.api.DecryptionCard
 import com.aliernfrog.ensimanager.ui.component.form.FormHeader
-import com.aliernfrog.ensimanager.ui.component.form.FormSection
-import com.aliernfrog.ensimanager.ui.component.form.SwitchRow
 import com.aliernfrog.ensimanager.ui.dialog.DeleteConfirmationDialog
 import com.aliernfrog.ensimanager.ui.sheet.APIProfileSheet
 import com.aliernfrog.ensimanager.ui.theme.AppComponentShape
@@ -191,25 +188,7 @@ fun APIProfilesScreen(
             }
 
             item {
-                FormSection(
-                    title = stringResource(R.string.api_profiles_settings),
-                    topDivider = true,
-                    bottomDivider = false
-                ) {
-                    SwitchRow(
-                        title = stringResource(R.string.api_profiles_settings_rememberLast),
-                        description = stringResource(R.string.api_profiles_settings_rememberLast_description),
-                        painter = rememberVectorPainter(Icons.Default.Bookmark),
-                        checked = apiViewModel.prefs.rememberLastAPIProfile.value
-                    ) {
-                        apiViewModel.prefs.rememberLastAPIProfile.value = it
-                    }
-                }
-
-                Spacer(
-                    Modifier
-                        .navigationBarsPadding()
-                        .height(AppFABPadding))
+                Spacer(Modifier.navigationBarsPadding().height(AppFABPadding))
             }
         }
     }

--- a/app/src/main/java/com/aliernfrog/ensimanager/ui/screen/settings/APIPage.kt
+++ b/app/src/main/java/com/aliernfrog/ensimanager/ui/screen/settings/APIPage.kt
@@ -56,7 +56,7 @@ fun APIPage(
         ) {
             RadioButtons(
                 choices = defaultProfileChoices,
-                selectedOptionIndex = apiViewModel.prefs.defaultAPIProfileIndex.value,
+                selectedIndex = apiViewModel.prefs.defaultAPIProfileIndex.value,
                 onSelect = { index ->
                     apiViewModel.prefs.defaultAPIProfileIndex.value = index
                 }

--- a/app/src/main/java/com/aliernfrog/ensimanager/ui/screen/settings/APIPage.kt
+++ b/app/src/main/java/com/aliernfrog/ensimanager/ui/screen/settings/APIPage.kt
@@ -26,6 +26,12 @@ fun APIPage(
         title = stringResource(R.string.settings_api),
         onNavigateBackRequest = onNavigateBackRequest
     ) {
+        SwitchRow(
+            title = stringResource(R.string.settings_api_rememberLast),
+            checked = apiViewModel.prefs.rememberLastSelectedAPIProfile.value
+        ) {
+            apiViewModel.prefs.rememberLastSelectedAPIProfile.value = it
+        }
         ExpandableRow(
             title = stringResource(R.string.settings_api_defaultProfile),
             description = stringResource(R.string.settings_api_defaultProfile_description),
@@ -34,12 +40,6 @@ fun APIPage(
                 defaultProfileChoicesExpanded = !defaultProfileChoicesExpanded
             }
         ) {
-            SwitchRow(
-                title = stringResource(R.string.settings_api_rememberLast),
-                checked = apiViewModel.prefs.rememberLastSelectedAPIProfile.value
-            ) {
-                apiViewModel.prefs.rememberLastSelectedAPIProfile.value = it
-            }
             RadioButtons(
                 choices = listOf(
                     *apiViewModel.apiProfiles.map {

--- a/app/src/main/java/com/aliernfrog/ensimanager/ui/screen/settings/APIPage.kt
+++ b/app/src/main/java/com/aliernfrog/ensimanager/ui/screen/settings/APIPage.kt
@@ -24,11 +24,7 @@ fun APIPage(
     val defaultProfileChoices = listOf(
         *apiViewModel.apiProfiles.map {
             val available = it.isAvailable
-            RadioButtonChoice(
-                title = it.name,
-                description = if (available) null else stringResource(R.string.api_profiles_switcher_unavailable),
-                enabled = available
-            )
+            RadioButtonChoice(title = it.name)
         }.toTypedArray(),
         RadioButtonChoice(
             title = stringResource(R.string.settings_api_defaultProfile_none),

--- a/app/src/main/java/com/aliernfrog/ensimanager/ui/screen/settings/APIPage.kt
+++ b/app/src/main/java/com/aliernfrog/ensimanager/ui/screen/settings/APIPage.kt
@@ -1,0 +1,65 @@
+package com.aliernfrog.ensimanager.ui.screen.settings
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.res.stringResource
+import com.aliernfrog.ensimanager.R
+import com.aliernfrog.ensimanager.data.api.isAvailable
+import com.aliernfrog.ensimanager.ui.component.form.RadioButtons
+import com.aliernfrog.ensimanager.ui.component.form.ExpandableRow
+import com.aliernfrog.ensimanager.ui.component.form.RadioButtonChoice
+import com.aliernfrog.ensimanager.ui.component.form.SwitchRow
+import com.aliernfrog.ensimanager.ui.viewmodel.APIViewModel
+import org.koin.androidx.compose.koinViewModel
+
+@Composable
+fun APIPage(
+    apiViewModel: APIViewModel = koinViewModel(),
+    onNavigateBackRequest: () -> Unit
+) {
+    var defaultProfileChoicesExpanded by rememberSaveable { mutableStateOf(false) }
+
+    SettingsPageContainer(
+        title = stringResource(R.string.settings_api),
+        onNavigateBackRequest = onNavigateBackRequest
+    ) {
+        ExpandableRow(
+            title = stringResource(R.string.settings_api_defaultProfile),
+            description = stringResource(R.string.settings_api_defaultProfile_description),
+            expanded = defaultProfileChoicesExpanded,
+            onClickHeader = {
+                defaultProfileChoicesExpanded = !defaultProfileChoicesExpanded
+            }
+        ) {
+            SwitchRow(
+                title = stringResource(R.string.settings_api_rememberLast),
+                checked = apiViewModel.prefs.rememberLastSelectedAPIProfile.value
+            ) {
+                apiViewModel.prefs.rememberLastSelectedAPIProfile.value = it
+            }
+            RadioButtons(
+                choices = listOf(
+                    *apiViewModel.apiProfiles.map {
+                        val available = it.isAvailable
+                        RadioButtonChoice(
+                            title = it.name,
+                            description = if (available) null else stringResource(R.string.api_profiles_switcher_unavailable),
+                            enabled = available
+                        )
+                    }.toTypedArray(),
+                    RadioButtonChoice(
+                        title = stringResource(R.string.settings_api_defaultProfile_none),
+                        indexOverride = -1
+                    ),
+                ),
+                selectedOptionIndex = 0,
+                onSelect = { index ->
+                    apiViewModel.prefs.defaultAPIProfileIndex.value = index
+                }
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/aliernfrog/ensimanager/ui/screen/settings/APIPage.kt
+++ b/app/src/main/java/com/aliernfrog/ensimanager/ui/screen/settings/APIPage.kt
@@ -23,7 +23,6 @@ fun APIPage(
     var defaultProfileChoicesExpanded by rememberSaveable { mutableStateOf(false) }
     val defaultProfileChoices = listOf(
         *apiViewModel.apiProfiles.map {
-            val available = it.isAvailable
             RadioButtonChoice(title = it.name)
         }.toTypedArray(),
         RadioButtonChoice(

--- a/app/src/main/java/com/aliernfrog/ensimanager/ui/screen/settings/APIPage.kt
+++ b/app/src/main/java/com/aliernfrog/ensimanager/ui/screen/settings/APIPage.kt
@@ -60,20 +60,7 @@ fun APIPage(
             }
         ) {
             RadioButtons(
-                choices = listOf(
-                    *apiViewModel.apiProfiles.map {
-                        val available = it.isAvailable
-                        RadioButtonChoice(
-                            title = it.name,
-                            description = if (available) null else stringResource(R.string.api_profiles_switcher_unavailable),
-                            enabled = available
-                        )
-                    }.toTypedArray(),
-                    RadioButtonChoice(
-                        title = stringResource(R.string.settings_api_defaultProfile_none),
-                        indexOverride = -1
-                    ),
-                ),
+                choices = defaultProfileChoices,
                 selectedOptionIndex = apiViewModel.prefs.defaultAPIProfileIndex.value,
                 onSelect = { index ->
                     apiViewModel.prefs.defaultAPIProfileIndex.value = index

--- a/app/src/main/java/com/aliernfrog/ensimanager/ui/screen/settings/APIPage.kt
+++ b/app/src/main/java/com/aliernfrog/ensimanager/ui/screen/settings/APIPage.kt
@@ -21,6 +21,23 @@ fun APIPage(
     onNavigateBackRequest: () -> Unit
 ) {
     var defaultProfileChoicesExpanded by rememberSaveable { mutableStateOf(false) }
+    val defaultProfileChoices = listOf(
+        *apiViewModel.apiProfiles.map {
+            val available = it.isAvailable
+            RadioButtonChoice(
+                title = it.name,
+                description = if (available) null else stringResource(R.string.api_profiles_switcher_unavailable),
+                enabled = available
+            )
+        }.toTypedArray(),
+        RadioButtonChoice(
+            title = stringResource(R.string.settings_api_defaultProfile_none),
+            indexOverride = -1
+        )
+    )
+    val chosenDefaultProfileName = apiViewModel.prefs.defaultAPIProfileIndex.value.let {
+        defaultProfileChoices.elementAtOrNull(it)?.title ?: stringResource(R.string.settings_api_defaultProfile_none)
+    }
 
     SettingsPageContainer(
         title = stringResource(R.string.settings_api),
@@ -32,9 +49,11 @@ fun APIPage(
         ) {
             apiViewModel.prefs.rememberLastSelectedAPIProfile.value = it
         }
+        
         ExpandableRow(
             title = stringResource(R.string.settings_api_defaultProfile),
             description = stringResource(R.string.settings_api_defaultProfile_description),
+            trailingButtonText = chosenDefaultProfileName,
             expanded = defaultProfileChoicesExpanded,
             onClickHeader = {
                 defaultProfileChoicesExpanded = !defaultProfileChoicesExpanded
@@ -55,7 +74,7 @@ fun APIPage(
                         indexOverride = -1
                     ),
                 ),
-                selectedOptionIndex = 0,
+                selectedOptionIndex = apiViewModel.prefs.defaultAPIProfileIndex.value,
                 onSelect = { index ->
                     apiViewModel.prefs.defaultAPIProfileIndex.value = index
                 }

--- a/app/src/main/java/com/aliernfrog/ensimanager/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/aliernfrog/ensimanager/ui/screen/settings/SettingsScreen.kt
@@ -42,7 +42,6 @@ import com.aliernfrog.ensimanager.ui.component.AppScaffold
 import com.aliernfrog.ensimanager.ui.component.AppSmallTopBar
 import com.aliernfrog.ensimanager.ui.component.AppTopBar
 import com.aliernfrog.ensimanager.ui.component.form.ButtonRow
-import com.aliernfrog.ensimanager.ui.screen.APIProfilesScreen
 import com.aliernfrog.ensimanager.ui.theme.AppComponentShape
 import com.aliernfrog.ensimanager.ui.viewmodel.MainViewModel
 import com.aliernfrog.ensimanager.util.extension.popBackStackSafe
@@ -224,10 +223,7 @@ enum class SettingsPage(
         description = R.string.settings_api_description,
         icon = Icons.Outlined.Api,
         content = { onNavigateBackRequest, _ ->
-            APIProfilesScreen(
-                onNavigateSettingsRequest = null,
-                onNavigateBackRequest = onNavigateBackRequest
-            )
+            APIPage(onNavigateBackRequest = onNavigateBackRequest)
         }
     ),
 

--- a/app/src/main/java/com/aliernfrog/ensimanager/ui/sheet/APIProfileSwitcherSheet.kt
+++ b/app/src/main/java/com/aliernfrog/ensimanager/ui/sheet/APIProfileSwitcherSheet.kt
@@ -68,18 +68,6 @@ fun APIProfileSwitchSheet(
                     onSettingsClick()
                 }
             },
-            {
-                ButtonRow(
-                    title = stringResource(R.string.api_profiles),
-                    painter = rememberVectorPainter(Icons.Default.Api),
-                    containerColor = MaterialTheme.colorScheme.surfaceContainerHighest
-                ) {
-                    scope.launch {
-                        onNavigateApiProfilesRequest()
-                        sheetState.hide()
-                    }
-                }
-            },
             modifier = Modifier.padding(horizontal = 8.dp)
         )
 
@@ -115,6 +103,18 @@ fun APIProfileSwitchSheet(
         ) {
             VerticalSegmentor(
                 *profileButtons.toTypedArray(),
+                {
+                    ButtonRow(
+                        title = stringResource(R.string.api_profiles_switcher_manageProfiles),
+                        painter = rememberVectorPainter(Icons.Default.Api),
+                        containerColor = MaterialTheme.colorScheme.surfaceContainerHighest
+                    ) {
+                        scope.launch {
+                            onNavigateApiProfilesRequest()
+                            sheetState.hide()
+                        }
+                    }
+                },
                 modifier = Modifier.padding(horizontal = 8.dp)
             )
         }

--- a/app/src/main/java/com/aliernfrog/ensimanager/ui/viewmodel/APIViewModel.kt
+++ b/app/src/main/java/com/aliernfrog/ensimanager/ui/viewmodel/APIViewModel.kt
@@ -156,7 +156,6 @@ class APIViewModel(
             apiProfiles.addAll(
                 gson.fromJson(profilesData, Array<APIProfile>::class.java)
             )
-            selectDefaultAPIProfile()
         } catch (_: Exception) {
             try {
                 // Might be encrypted, ask user for password if so

--- a/app/src/main/java/com/aliernfrog/ensimanager/util/manager/PreferenceManager.kt
+++ b/app/src/main/java/com/aliernfrog/ensimanager/util/manager/PreferenceManager.kt
@@ -13,9 +13,9 @@ class PreferenceManager(context: Context) : BasePreferenceManager(
     val pitchBlack = booleanPreference("pitchBlack", false)
 
     // API
-    val rememberLastAPIProfile = booleanPreference("rememberLastApiProfile", true)
     val apiProfiles = stringPreference("apiProfiles", "[]")
-    val lastActiveAPIProfileId = stringPreference("lastActiveApiProfileId", experimental = true, includeInDebugInfo = false)
+    val rememberLastSelectedAPIProfile = booleanPreference("rememberLastSelectedApiProfile", false)
+    val defaultAPIProfileIndex = intPreference("defaultApiProfileIndex", -1, experimental = true, includeInDebugInfo = false)
 
     @Deprecated("This should only be used for migration purposes")
     val legacyAPIURL = stringPreference("apiEndpointsUrl", experimental = true, includeInDebugInfo = false)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,9 +44,6 @@
     <string name="api_profiles_add_sha256_info">If this does not match with the one provided by server, requests will be aborted\nLeave empty to automatically pull from the server</string>
     <string name="api_profiles_add_sha256_notHttps">Only available for HTTPS profiles</string>
     <string name="api_profiles_add_saved">Saved profile</string>
-    <string name="api_profiles_settings">Settings</string>
-    <string name="api_profiles_settings_rememberLast">Remember last chosen profile</string>
-    <string name="api_profiles_settings_rememberLast_description">Automatically select last chosen profile on app launch</string>
     <string name="api_crypto_encrypt">Encrypt Ensi Manager</string>
     <string name="api_crypto_encrypt_description">Encrypt your profiles and authorization details to improve security</string>
     <string name="api_crypto_encrypt_do">Encrypt</string>
@@ -102,7 +99,11 @@
     <string name="settings_appearance_pitchBlack">Pitch black</string>
     <string name="settings_appearance_pitchBlack_description">Pitch black background when dark mode is enabled</string>
     <string name="settings_api">API profiles</string>
-    <string name="settings_api_description">Configure profiles for APIs</string>
+    <string name="settings_api_description">Configure behavior for API profiles</string>
+    <string name="settings_api_rememberLast">Remember last selected API profile</string>
+    <string name="settings_api_defaultProfile">Default profile</string>
+    <string name="settings_api_defaultProfile_description">Profile to automatically select on launch</string>
+    <string name="settings_api_defaultProfile_none">None</string>
     <string name="settings_security">Security</string>
     <string name="settings_security_description">Improve security by encrypting Ensi Manager</string>
     <string name="settings_security_encryption">Encrypt profiles</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="api_profiles_switcher">Profiles and settings</string>
     <string name="api_profiles_switcher_update">Update available</string>
     <string name="api_profiles_switcher_unavailable">API unavailable, check profile configuration for more info</string>
+    <string name="api_profiles_switcher_manageProfiles">Manage API profiles</string>
     <string name="api_profiles_restoreError">Failed to restore saved profiles</string>
     <string name="api_profiles_migratedFromV2">Migrated from v2</string>
     <string name="api_profiles_empty">No profiles found</string>


### PR DESCRIPTION
* added "Default API profile" option to settings > API Profiles

* fixed "Remember last profile" option when used with encryption

* "Remember last profile" now uses index to not expose unencrypted endpoints URL of the last selected profile

* moved "Remember last profile" toggle to settings > API Profiles

* removed profile management from API profiles page in settings

* ui changes to profile switcher bottom sheet